### PR TITLE
Update revm dependency spec to account for new transaction types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ alloy-primitives = { version = "=0.8.11", default-features = false, features = [
     "tiny-keccak",
 ] }
 reth-primitives = { git = "https://github.com/lita-xyz/reth.git", branch = "1.1.1-delendum", default-features = false }
-revm = { version = "14.0.0", features = ["std"], default-features = false }
+revm = { version = "15.0.0", features = ["std", "c-kzg", "optional_balance_check"], default-features = false }
 anyhow = "1.0.75"
 hashbrown = "0.14.3"
 ethers-core = "2.0.13"


### PR DESCRIPTION
We need c-zkg to be able to prepare our blocks containing any Eip4844 blob versioned hash fields. And we also want to ignore any errors about balance checks. So the revm dependency is configured accordingly in this commit. Also taking the opportunity to upgrade to 15.0